### PR TITLE
pass url resolution through to node.js url.resolve

### DIFF
--- a/lib/core/util/docToModel.js
+++ b/lib/core/util/docToModel.js
@@ -26,13 +26,13 @@ function documentToModel(url,doc,cb){
     //platformGet may be undefined, and we can continue without it, hence the guard
     if(pm.platform.getResourceFromUrl){
         inlineSrcs(url,doc,function(errors){
-            if(errors){ 
+            if(errors){
                 //treat script download errors as fatal
                 //pass through a single error - aggregate if there's more than one
-                cb(errors.length === 1 ? 
-                        errors[0].err : 
+                cb(errors.length === 1 ?
+                        errors[0].err :
                         new Error(
-                            'Script download errors : \n' + 
+                            'Script download errors : \n' +
                                 errors.map(function(oErr){return oErr.url + ': ' + oErr.err.message;}).join('\n')));
             }else{
                 //otherwise, attempt to convert document to model object
@@ -47,40 +47,51 @@ function documentToModel(url,doc,cb){
 function docToModel(url,doc,cb){
     try {
         var annotatedScxmlJson = annotator.transform(doc);
-        var model = json2model(annotatedScxmlJson,url); 
+        var model = json2model(annotatedScxmlJson,url);
         cb(null,model);
     }catch(e){
         cb(e);
     }
 }
 
+function fixupUrl(baseUrl, targetUrl) {
+    var newUrl;
+    if (pm.platform.url.resolve) {
+        newUrl = pm.platform.url.resolve(baseUrl, targetUrl);
+    } else {
+        var documentUrlPath = pm.platform.url.getPathFromUrl(baseUrl);
+        var documentDir = pm.platform.path.dirname(documentUrlPath);
+        var scriptPath = pm.platform.path.join(documentDir,targetUrl);
+        newUrl = pm.platform.url.changeUrlPath(baseUrl,scriptPath);
+    }
+
+    return newUrl;
+}
+
 function inlineSrcs(url,doc,cb){
     //console.log('inlining scripts');
-    
+
     var scriptActionsWithSrcAttributes = [], errors = [];
 
-    traverse(doc.documentElement,scriptActionsWithSrcAttributes); 
+    traverse(doc.documentElement,scriptActionsWithSrcAttributes);
 
     //async forEach
     function retrieveScripts(){
         var script = scriptActionsWithSrcAttributes.pop();
         if(script){
             //quick and dirty for now:
-            //to be totally correct, what we need to do here is: 
+            //to be totally correct, what we need to do here is:
             //parse the url, extract the pathname, call dirname on path, and join that with the path to the file
             var scriptUrl = pm.platform.dom.getAttribute(script,"src");
             if(url){
-                var documentUrlPath = pm.platform.url.getPathFromUrl(url);
-                var documentDir = pm.platform.path.dirname(documentUrlPath);
-                var scriptPath = pm.platform.path.join(documentDir,scriptUrl);
-                scriptUrl = pm.platform.url.changeUrlPath(url,scriptPath);
+                scriptUrl = fixupUrl(url, scriptUrl);
             }
             //platform.log('fetching script src',scriptUrl);
             pm.platform.getResourceFromUrl(scriptUrl,function(err,text){
                 if(err){
                     //just capture the error, and continue on
                     pm.platform.log("Error downloading document " + scriptUrl + " : " + err.message);
-                    errors.push({url : scriptUrl, err : err}); 
+                    errors.push({url : scriptUrl, err : err});
                 }else{
                     pm.platform.dom.textContent(script,text);
                 }
@@ -95,8 +106,8 @@ function inlineSrcs(url,doc,cb){
 
 function traverse(node,nodeList){
     if((pm.platform.dom.localName(node) === 'script' || pm.platform.dom.localName(node) === 'data') && pm.platform.dom.hasAttribute(node,"src")){
-        nodeList.push(node); 
-    } 
+        nodeList.push(node);
+    }
 
     pm.platform.dom.getElementChildren(node).forEach(function(child){traverse(child,nodeList);});
 }

--- a/lib/node/url.js
+++ b/lib/node/url.js
@@ -20,16 +20,20 @@ var urlModule = require('url');
 
 module.exports = {
     getPathFromUrl : function(url){
-        var oUrl = urlModule.parse(url); 
+        var oUrl = urlModule.parse(url);
         return oUrl.pathname;
     },
 
     changeUrlPath : function(url,newPath){
-        var oUrl = urlModule.parse(url); 
+        var oUrl = urlModule.parse(url);
 
         oUrl.path = oUrl.pathname = newPath;
 
         return urlModule.format(oUrl);
+    },
+
+    resolve: function(base, target) {
+        return urlModule.resolve(base, target);
     }
 };
 


### PR DESCRIPTION
The existing url resolution code produces URLs with backslashes on windows. Rather than fixing up the helpers, exporting a resolve function and passing through to node.js's url.resolve in that environment seemed a reasonable approach.
