### PR TITLE
kick off fetches for external resources in parallel

### DIFF
--- a/lib/core/util/docToModel.js
+++ b/lib/core/util/docToModel.js
@@ -68,40 +68,42 @@ function fixupUrl(baseUrl, targetUrl) {
     return newUrl;
 }
 
-function inlineSrcs(url,doc,cb){
+function inlineSrcs(docUrl,doc,cb){
     //console.log('inlining scripts');
 
-    var scriptActionsWithSrcAttributes = [], errors = [];
+    var nodesWithSrcAttributes = [], errors = [], resultCount = 0;
 
-    traverse(doc.documentElement,scriptActionsWithSrcAttributes);
+    traverse(doc.documentElement,nodesWithSrcAttributes);
 
-    //async forEach
-    function retrieveScripts(){
-        var script = scriptActionsWithSrcAttributes.pop();
-        if(script){
-            //quick and dirty for now:
-            //to be totally correct, what we need to do here is:
-            //parse the url, extract the pathname, call dirname on path, and join that with the path to the file
-            var scriptUrl = pm.platform.dom.getAttribute(script,"src");
-            if(url){
-                scriptUrl = fixupUrl(url, scriptUrl);
+    if (nodesWithSrcAttributes.length) {
+        // kick off fetches in parallel
+        nodesWithSrcAttributes.forEach(function(node, idx) {
+            var nodeUrl = pm.platform.dom.getAttribute(node,"src");
+            if(docUrl) {
+                nodeUrl = fixupUrl(docUrl, nodeUrl);
             }
-            //platform.log('fetching script src',scriptUrl);
-            pm.platform.getResourceFromUrl(scriptUrl,function(err,text){
+
+           /* TBD: For data elements, use mimeType (aka Content-Type returned by HTTP server (if any))
+                     *  to determine how to process the external resource.
+                     *  e.g. treat application/json as JSON per hint in C.2.1 of http://www.w3.org/TR/scxml/#profiles
+                     */
+            pm.platform.getResourceFromUrl(nodeUrl,function(err,text,mimeType){
                 if(err){
                     //just capture the error, and continue on
-                    pm.platform.log("Error downloading document " + scriptUrl + " : " + err.message);
-                    errors.push({url : scriptUrl, err : err});
+                    pm.platform.log("Error downloading document " + nodeUrl + " : " + err.message);
+                    errors.push({url : nodeUrl, err : err});
                 }else{
-                    pm.platform.dom.textContent(script,text);
+                    pm.platform.dom.textContent(node,text);
                 }
-                retrieveScripts();
+                ++resultCount;
+                if (resultCount == nodesWithSrcAttributes.length) {
+                    cb(errors.length ? errors : null);
+                }
             });
-        }else{
-            cb(errors.length ? errors : null);
-        }
+        });
+    } else {
+        cb();
     }
-    retrieveScripts();  //kick him off
 }
 
 function traverse(node,nodeList){


### PR DESCRIPTION
For the parallel enhancement, my test .scxml contained a datamodel like so:

  <data id="d0" src="sleep-json.cgi?secs=5"/>
  <data id="d1" src="data1.json"/>
  <data id="d2" src="data2.json"/>

Here's the log:

2013-01-14 22:56:10.749 FLDR: INFO HTTP GET BEGIN [uri=http://localhost:8888/scxmltests/misc/sleep-json.cgi?secs=5]
2013-01-14 22:56:10.751 FLDR: INFO HTTP GET BEGIN [uri=http://localhost:8888/scxmltests/misc/data1.json]
2013-01-14 22:56:10.754 FLDR: INFO HTTP GET BEGIN [uri=http://localhost:8888/scxmltests/misc/data2.json]
...
2013-01-14 22:56:10.765 FLDR: INFO HTTP GET END. [uri=http://localhost:8888/scxmltests/misc/data1.json]
2013-01-14 22:56:10.765 FLDR: INFO HTTP GET END. [uri=http://localhost:8888/scxmltests/misc/data2.json]
2013-01-14 22:56:15.951 FLDR: INFO HTTP GET END. [uri=http://localhost:8888/scxmltests/misc/sleep-json.cgi?secs=5]

Also added mimeType parameter to getResourceFromUrl API to suggest a mechanism (via the HTTP Content-Type) for the interpreter to determine how to process/reflect the resulting content. In hindsight, I should have saved that for a subsequent issue/discussion.
