### PR TITLE
Adds possibility to ignore <script>

### DIFF
--- a/lib/core/scxml/SCXML.js
+++ b/lib/core/scxml/SCXML.js
@@ -51,6 +51,7 @@ function SCXMLInterpreter(model, opts){
     this.opts.EventSet = this.opts.EventSet || ArraySet;
     this.opts.TransitionPairSet = this.opts.TransitionPairSet || ArraySet;
     this.opts.priorityComparisonFn = this.opts.priorityComparisonFn || getTransitionWithHigherSourceChildPriority(this.opts.model);
+    this.opts.ignoreScript = false;
 
     this._sessionid = this.opts.sessionid || "";
 
@@ -283,6 +284,7 @@ SCXMLInterpreter.prototype = {
 
     /** @private */
     _evaluateAction : function(actionRef, eventSet, datamodelForNextStep, eventsToAddToInnerQueue) {
+        if(this.opts.ignoreScript) return;
         function $raise(event){
             eventsToAddToInnerQueue.add(event);
         }


### PR DESCRIPTION
This little change makes it possible to ignore all <script>-tags.
This is achieved by the flag 'this.opts.ignoreScript'
