### PR TITLE
sendId -> sendid, since lowercase is used elsewhere

### DIFF
--- a/lib/core/util/code-gen.js
+++ b/lib/core/util/code-gen.js
@@ -136,7 +136,7 @@ var actionTags = {
                 "}else{\n" +
                     "$send(" + event + ", {\n" +
                         "delay: " + (pm.platform.dom.hasAttribute(action,"delayexpr") ? 'getDelayInMs(' + pm.platform.dom.getAttribute(action,"delayexpr") + ')' : getDelayInMs(pm.platform.dom.getAttribute(action,"delay"))) + ",\n" +
-                        "sendId: " + (pm.platform.dom.hasAttribute(action,"idlocation") ? pm.platform.dom.getAttribute(action,"idlocation") : JSON.stringify(pm.platform.dom.getAttribute(action,"id"))) + "\n" +
+                        "sendid: " + (pm.platform.dom.hasAttribute(action,"idlocation") ? pm.platform.dom.getAttribute(action,"idlocation") : JSON.stringify(pm.platform.dom.getAttribute(action,"id"))) + "\n" +
                     "}, $raise);" +
                 "}";
 


### PR DESCRIPTION
See bug exposed here (and when the "I" is replaced with an "i" the problem goes away).

http://jsfiddle.net/qmLsqh0j/2/

SimpleInterpreter.prototype._send looks for "options.sendid" not "options.sendId" which meant that the id attribute was ignored altogether, making them impossible to cancel.  Cancelling events now work.  How goes it with "scion-ng" ?
