### PR TITLE
Fix canceling delayed events

### DIFF
--- a/lib/core/util/code-gen.js
+++ b/lib/core/util/code-gen.js
@@ -136,7 +136,7 @@ var actionTags = {
                 "}else{\n" +
                     "$send(" + event + ", {\n" +
                         "delay: " + (pm.platform.dom.hasAttribute(action,"delayexpr") ? 'getDelayInMs(' + pm.platform.dom.getAttribute(action,"delayexpr") + ')' : getDelayInMs(pm.platform.dom.getAttribute(action,"delay"))) + ",\n" +
-                        "sendId: " + (pm.platform.dom.hasAttribute(action,"idlocation") ? pm.platform.dom.getAttribute(action,"idlocation") : JSON.stringify(pm.platform.dom.getAttribute(action,"id"))) + "\n" +
+                        "sendid: " + (pm.platform.dom.hasAttribute(action,"idlocation") ? pm.platform.dom.getAttribute(action,"idlocation") : JSON.stringify(pm.platform.dom.getAttribute(action,"id"))) + "\n" +
                     "}, $raise);" +
                 "}";
 


### PR DESCRIPTION
Delayed events aren't canceled correctly, because "sendid" is not the same as "sendId".  

The bug is exposed here : http://jsfiddle.net/qmLsqh0j/2/  The events are cancelled when the state is exited, but the events fire nonetheless.  This change fixes that.
