### PR TITLE
Fix node v0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
   - 0.10
+  - 0.8
 before_install:
-  - npm install -g npm@~1.4.10
+  - npm install -g npm@~2.6.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ node_js:
   - 0.10
   - 0.8
 before_install:
-  - npm install -g npm@~2.6.1
+  - npm install -g npm

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "engines": {
     "node": ">=0.8",
-    "npm": "1.4.10"
+    "npm": ">=2.0.0"
   },
   "main": "./lib/runtime/platform-bootstrap/node/index.js",
   "scripts": {


### PR DESCRIPTION
Closes #322 

- Problem was `^` version selector character.

request library had a dependency that uses the character and npm v1.4.10 had a bug with it. I moved npm version to minimum of 2.0 