### PR TITLE
Fix node v012

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - 0.12
   - 0.10
   - 0.8
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: node_js
 node_js:
   - 0.12
+  - 0.11
   - 0.10
+  - 0.9
   - 0.8
 before_install:
   - npm install -g npm


### PR DESCRIPTION
Closes #344 

Scion is tested agains these versions. 
- v0.12 (graphical cli log problem)
- v0.11 (graphical cli log problem)
- v0.10
- v0.09
- v0.08

Only 11 and 12 has a problem with cli table logging doesn't work as expected. It is merely a cosmetic issue.

![screenshot 2015-03-05 15 42 03](https://cloud.githubusercontent.com/assets/2324045/6505801/60d56aa8-c34e-11e4-8504-50bc46fa3c5b.png)
