### PR TITLE
Fix node versions on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - 0.12
   - 0.10
   - 0.8
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ node_js:
   - 0.12
   - 0.11
   - 0.10
-  - 0.9
   - 0.8
 before_install:
   - npm install -g npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
   - 0.10
+  - 0.8
 before_install:
-  - npm install -g npm@~1.4.10
+  - npm install -g npm@~2.6.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ node_js:
   - 0.10
   - 0.8
 before_install:
-  - npm install -g npm@~2.6.1
+  - npm install -g npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: node_js
 node_js:
   - 0.12
+  - 0.11
   - 0.10
+  - 0.9
   - 0.8
 before_install:
   - npm install -g npm

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "engines": {
     "node": ">=0.8",
-    "npm": "1.4.10"
+    "npm": ">=2.0.0"
   },
   "main": "./lib/runtime/platform-bootstrap/node/index.js",
   "scripts": {


### PR DESCRIPTION
Closes #322  (node v0.8)

- Problem was `^` version selector character.

request library had a dependency that uses the character and npm v1.4.10 had a bug with it. I moved npm version to minimum of 2.0 


Closes #344 

Scion is tested agains these versions. 
- v0.12 (graphical cli log problem)
- v0.11 (graphical cli log problem)
- v0.10
- v0.08

Problems:
- Only v0.11 and v0.12 has a problem with cli table logging doesn't work as expected. It is merely a cosmetic issue. See below screenshot.
- v0.09 is not tested because it has an npm bug.

![screenshot 2015-03-05 15 42 03](https://cloud.githubusercontent.com/assets/2324045/6505801/60d56aa8-c34e-11e4-8504-50bc46fa3c5b.png)
