### PR TITLE
Add CDNJS version badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Overview
+# Overview [![CDNJS](https://img.shields.io/cdnjs/v/scion.svg)](https://cdnjs.com/libraries/scion)
 
 SCION is an industrial-strength implementation of [W3C SCXML](http://www.w3.org/TR/scxml/) in JavaScript. 
 


### PR DESCRIPTION
This will add a badge that shows the lib version on CDNJS and link to its page on CDNJS!
